### PR TITLE
Replaced episode duration field with endtime field

### DIFF
--- a/digital-logsheets-res/php/validator/EpisodeValidator.php
+++ b/digital-logsheets-res/php/validator/EpisodeValidator.php
@@ -42,12 +42,8 @@ class EpisodeValidator {
         $this->episode = $episode;
     }
 
-    public function checkDraftSaveValidity($durationHours) {
+    public function checkDraftSaveValidity() {
         $errorsContainer = new SaveEpisodeErrors();
-
-        if (!is_numeric($durationHours)) {
-            $errorsContainer->markDurationMissing();
-        }
 
         $this->areRequiredFieldsPresent($errorsContainer);
         $this->isEpisodeLengthValid($errorsContainer);
@@ -115,12 +111,11 @@ class EpisodeValidator {
         if (!ValidatorUtility::doesFieldExist($startTime)) {
             $errorsContainer->markStartTimeMissing();
 
-        } else {
-            $endTime = $this->episode->getEndTime();
-            if (!ValidatorUtility::doesFieldExist($endTime)) {
-                //TODO: is it enough to check end time as proxy for duration?
-                $errorsContainer->markDurationMissing();
-            }
+        }
+
+        $endTime = $this->episode->getEndTime();
+        if (!ValidatorUtility::doesFieldExist($endTime)) {
+            $errorsContainer->markEndTimeMissing();
         }
     }
 

--- a/digital-logsheets-res/php/validator/EpisodeValidator.php
+++ b/digital-logsheets-res/php/validator/EpisodeValidator.php
@@ -150,10 +150,12 @@ class EpisodeValidator {
 
         if ($episodeIntervalDaysComponent != false && $episodeIntervalDaysComponent > 0) {
             $episodeLengthInHours =  ($episodeIntervalDaysComponent * 24) +
-                $episodeIntervalHoursComponent + ($episodeIntervalMinutesComponent / 60);
+                $episodeIntervalHoursComponent +
+                ($episodeIntervalMinutesComponent / 60);
 
         } else {
-            $episodeLengthInHours = $episodeIntervalHoursComponent + ($episodeIntervalMinutesComponent / 60);
+            $episodeLengthInHours = $episodeIntervalHoursComponent +
+                ($episodeIntervalMinutesComponent / 60);
         }
 
         if ($episodeLengthInHours > self::EPISODE_MAX_LENGTH_HOURS) {

--- a/digital-logsheets-res/php/validator/errorContainers/SaveEpisodeErrors.php
+++ b/digital-logsheets-res/php/validator/errorContainers/SaveEpisodeErrors.php
@@ -9,7 +9,7 @@ class SaveEpisodeErrors extends ErrorsContainer {
             'missingProgram' => false,
             'missingProgrammer' => false,
             'missingStartTime' => false,
-            'missingDuration' => false,
+            'missingEndTime' => false,
             'tooLong' => false,
             'tooShort' => false,
             'airDateTooFarInPast' => false,
@@ -32,8 +32,8 @@ class SaveEpisodeErrors extends ErrorsContainer {
         $this->errors['missingStartTime'] = true;
     }
 
-    public function markDurationMissing() {
-        $this->errors['missingDuration'] = true;
+    public function markEndTimeMissing() {
+        $this->errors['missingEndTime'] = true;
     }
 
     public function markTooLong() {

--- a/digital-logsheets-res/templates/new-logsheet.tpl
+++ b/digital-logsheets-res/templates/new-logsheet.tpl
@@ -191,6 +191,27 @@
             </div>
 
 
+            <div id="end_datetime_group" class="form-group row{if $endDateTimeError} has-error{/if}">
+                <div class="col-md-2 col-sm-4">
+                    <label for="episode_end_datetime" class="control-label">End Date/Time:</label>
+                    <input class="form-control" type="number" step="any"
+                           name="episode_end_datetime" id="episode_end_datetime"
+                           value="{$formSubmission.duration}" required>
+                    <span id="end_datetime_help_block" class="help-block{if !$endDateTimeError} hidden{/if}">
+                            <span id="missing_duration_message" class="{if !$formErrors.missingEndTime}hidden{/if}">
+                                Please enter a valid end date/time.
+                            </span>
+                            <span id="too_short_message" class="{if $formErrors.tooShort}hidden{/if}">
+                                Episodes must be at least {$minDuration} hours long.
+                            </span>
+                            <span id="too_long_message" class="{if $formErrors.tooLong}hidden{/if}">
+                                Episodes must be less than {$maxDuration} hours long.
+                            </span>
+                        </span>
+                </div>
+            </div>
+
+
 
 
             {if $formErrors.missingPrerecordDate || $formErrors.prerecordDateInPast || $formErrors.prerecordDateInFuture}

--- a/digital-logsheets-res/templates/new-logsheet.tpl
+++ b/digital-logsheets-res/templates/new-logsheet.tpl
@@ -49,13 +49,16 @@
             });
 
             $('#start_datetime').change(function() {
-                adjustPrerecordDateBounds({$prerecordDateEarlyDaysLimit|json_encode}, {$prerecordDateLateDaysLimit|json_encode});
+                adjustPrerecordDateBounds({$prerecordDateEarlyDaysLimit|json_encode},
+                        {$prerecordDateLateDaysLimit|json_encode});
+                adjustEndDatetimeBounds({$minDuration}, {$maxDuration});
+
             }).focusout(function() {
                 verifyEpisodeStartDatetime();
             });
 
             $('#end_datetime').focusout(function() {
-                verifyEpisodeEndDateTime();
+                verifyEpisodeEndDatetime();
             });
 
             $('#prerecord_date').focusout(function() {
@@ -66,7 +69,7 @@
                 if (!verifyProgrammer() ||
                     !verifyProgram() ||
                     !verifyEpisodeStartDatetime() ||
-                    !verifyEpisodeEndDateTime() ||
+                    !verifyEpisodeEndDatetime() ||
                     !verifyPrerecordDate()) {
 
                     e.preventDefault();
@@ -163,39 +166,17 @@
 
 
 
-            {if $formErrors.missingDuration || $formErrors.tooShort || $formErrors.tooLong}
-                {assign var="durationError" value=true}
+            {if $formErrors.missingEndTime || $formErrors.tooShort || $formErrors.tooLong}
+                {assign var="endDateTimeError" value=true}
             {else}
-                {assign var="durationError" value=false}
+                {assign var="endDateTimeError" value=false}
             {/if}
 
-
-            <div id="duration_group" class="form-group row{if $durationError} has-error{/if}">
-                <div class="col-md-2 col-sm-4">
-                    <label for="episode_duration" class="control-label">Duration (in hours):</label>
-                    <input class="form-control" type="number" step="any"
-                           name="episode_duration" id="episode_duration"
-                           value="{$formSubmission.duration}" required>
-                    <span id="duration_help_block" class="help-block{if !$durationError} hidden{/if}">
-                        <span id="missing_duration_message" class="{if !$formErrors.missingDuration}hidden{/if}">
-                            Please enter a duration.
-                        </span>
-                        <span id="too_short_message" class="{if $formErrors.tooShort}hidden{/if}">
-                            Episode must be at least {$minDuration} hours long
-                        </span>
-                        <span id="too_long_message" class="{if $formErrors.tooLong}hidden{/if}">
-                            Episode must be less than {$maxDuration} hours long
-                        </span>
-                    </span>
-                </div>
-            </div>
-
-
             <div id="end_datetime_group" class="form-group row{if $endDateTimeError} has-error{/if}">
-                <div class="col-md-2 col-sm-4">
-                    <label for="episode_end_datetime" class="control-label">End Date/Time:</label>
-                    <input class="form-control" type="number" step="any"
-                           name="end_datetime" id="end_datetime"
+                <div class="col-md-3 col-sm-5">
+                    <label for="end_datetime" class="control-label">End Date/Time:</label>
+                    <input class="form-control" type="datetime-local"
+                           name="end_datetime" id="end_datetime" step="60"
                            value="{$formSubmission.endDateTime}" required>
                     <span id="end_datetime_help_block" class="help-block{if !$endDateTimeError} hidden{/if}">
                             <span id="missing_end_datetime_message" class="{if !$formErrors.missingEndTime}hidden{/if}">

--- a/digital-logsheets-res/templates/new-logsheet.tpl
+++ b/digital-logsheets-res/templates/new-logsheet.tpl
@@ -182,10 +182,10 @@
                             <span id="missing_end_datetime_message" class="{if !$formErrors.missingEndTime}hidden{/if}">
                                 Please enter a valid end date/time.
                             </span>
-                            <span id="too_short_message" class="{if $formErrors.tooShort}hidden{/if}">
+                            <span id="too_short_message" class="{if !$formErrors.tooShort}hidden{/if}">
                                 Episodes must be at least {$minDuration} hours long.
                             </span>
-                            <span id="too_long_message" class="{if $formErrors.tooLong}hidden{/if}">
+                            <span id="too_long_message" class="{if !$formErrors.tooLong}hidden{/if}">
                                 Episodes must be less than {$maxDuration} hours long.
                             </span>
                         </span>

--- a/digital-logsheets-res/templates/new-logsheet.tpl
+++ b/digital-logsheets-res/templates/new-logsheet.tpl
@@ -54,8 +54,8 @@
                 verifyEpisodeStartDatetime();
             });
 
-            $('#episode_duration').focusout(function() {
-                verifyEpisodeDuration();
+            $('#end_datetime').focusout(function() {
+                verifyEpisodeEndDateTime();
             });
 
             $('#prerecord_date').focusout(function() {
@@ -66,7 +66,7 @@
                 if (!verifyProgrammer() ||
                     !verifyProgram() ||
                     !verifyEpisodeStartDatetime() ||
-                    !verifyEpisodeDuration() ||
+                    !verifyEpisodeEndDateTime() ||
                     !verifyPrerecordDate()) {
 
                     e.preventDefault();
@@ -195,10 +195,10 @@
                 <div class="col-md-2 col-sm-4">
                     <label for="episode_end_datetime" class="control-label">End Date/Time:</label>
                     <input class="form-control" type="number" step="any"
-                           name="episode_end_datetime" id="episode_end_datetime"
-                           value="{$formSubmission.duration}" required>
+                           name="end_datetime" id="end_datetime"
+                           value="{$formSubmission.endDateTime}" required>
                     <span id="end_datetime_help_block" class="help-block{if !$endDateTimeError} hidden{/if}">
-                            <span id="missing_duration_message" class="{if !$formErrors.missingEndTime}hidden{/if}">
+                            <span id="missing_end_datetime_message" class="{if !$formErrors.missingEndTime}hidden{/if}">
                                 Please enter a valid end date/time.
                             </span>
                             <span id="too_short_message" class="{if $formErrors.tooShort}hidden{/if}">

--- a/public_html/digital-logsheets/js/validation/episodeValidation.js
+++ b/public_html/digital-logsheets/js/validation/episodeValidation.js
@@ -54,6 +54,21 @@ function adjustPrerecordDateBounds(prerecordEarlyDaysLimit, prerecordLateDaysLim
     prerecordDateInput.prop('max', upperBound);
 }
 
+function adjustEndDatetimeBounds(minDuration, maxDuration) {
+    var endDatetimeField = $('#end_datetime');
+    var endDateTime = _getDateFromField(endDatetimeField);
+
+    var earliestEnd = endDateTime.clone();
+    earliestEnd = earliestEnd.add(minDuration, 'hours');
+    var earliestEndString = earliestEnd.format('YYYY-MM-DD HH:mm:ss');
+    endDatetimeField.prop('min', earliestEndString);
+
+    var latestEnd = endDateTime.clone();
+    latestEnd = latestEnd.add(maxDuration, 'hours');
+    var latestEndString = latestEnd.format('YYYY-MM-DD HH:mm:ss');
+    endDatetimeField.prop('max', latestEndString);
+}
+
 function setDurationBounds(minDuration, maxDuration) {
     var endDateTimeField = $('#end_datetime');
 

--- a/public_html/digital-logsheets/js/validation/episodeValidation.js
+++ b/public_html/digital-logsheets/js/validation/episodeValidation.js
@@ -172,7 +172,7 @@ function verifyEpisodeStartDatetime() {
     }
 }
 
-function verifyEpisodeEndDateTime() {
+function verifyEpisodeEndDatetime() {
 
     var startDateTimeField = $('#start_datetime');
     var startDateTime = _getDateFromField(startDateTimeField);
@@ -192,7 +192,7 @@ function verifyEpisodeEndDateTime() {
     minDuration = +minDuration;
 
     var earliestEnd = startDateTime.clone();
-    earliestEnd = earliestEnd.add(minDuration);
+    earliestEnd = earliestEnd.add(minDuration, 'hours');
     if (endDateTime.isBefore(earliestEnd)) {
         markEpisodeDurationTooShort(endDateTimeGroup, helpBlock);
         return false;
@@ -203,7 +203,7 @@ function verifyEpisodeEndDateTime() {
     maxDuration = +maxDuration;
 
     var latestEnd = startDateTime.clone();
-    latestEnd = latestEnd.add(maxDuration);
+    latestEnd = latestEnd.add(maxDuration, 'hours');
     if (endDateTime.isAfter(latestEnd)) {
         markEpisodeDurationTooLong(endDateTimeGroup, helpBlock);
         return false;

--- a/public_html/digital-logsheets/js/validation/episodeValidation.js
+++ b/public_html/digital-logsheets/js/validation/episodeValidation.js
@@ -55,17 +55,19 @@ function adjustPrerecordDateBounds(prerecordEarlyDaysLimit, prerecordLateDaysLim
 }
 
 function adjustEndDatetimeBounds(minDuration, maxDuration) {
-    var endDatetimeField = $('#end_datetime');
-    var endDateTime = _getDateFromField(endDatetimeField);
+    var startDatetimeField = $('#start_datetime');
+    var startDateTime = _getDateFromField(startDatetimeField);
 
-    var earliestEnd = endDateTime.clone();
+    var endDatetimeField = $('#end_datetime');
+
+    var earliestEnd = startDateTime.clone();
     earliestEnd = earliestEnd.add(minDuration, 'hours');
-    var earliestEndString = earliestEnd.format('YYYY-MM-DD HH:mm:ss');
+    var earliestEndString = earliestEnd.format('YYYY-MM-DDTHH:mm:ss');
     endDatetimeField.prop('min', earliestEndString);
 
-    var latestEnd = endDateTime.clone();
+    var latestEnd = startDateTime.clone();
     latestEnd = latestEnd.add(maxDuration, 'hours');
-    var latestEndString = latestEnd.format('YYYY-MM-DD HH:mm:ss');
+    var latestEndString = latestEnd.format('YYYY-MM-DDTHH:mm:ss');
     endDatetimeField.prop('max', latestEndString);
 }
 

--- a/public_html/digital-logsheets/js/validation/episodeValidation.js
+++ b/public_html/digital-logsheets/js/validation/episodeValidation.js
@@ -55,9 +55,11 @@ function adjustPrerecordDateBounds(prerecordEarlyDaysLimit, prerecordLateDaysLim
 }
 
 function setDurationBounds(minDuration, maxDuration) {
-    var durationField = $('#episode_duration');
-    durationField.prop('min', minDuration);
-    durationField.prop('max', maxDuration);
+    var endDateTimeField = $('#end_datetime');
+
+    endDateTimeField.data('minDuration', minDuration);
+    endDateTimeField.data('maxDuration', maxDuration);
+
 }
 
 function setStartDateTimeBounds(earlyLimit, lateLimit) {
@@ -170,36 +172,38 @@ function verifyEpisodeStartDatetime() {
     }
 }
 
-function verifyEpisodeDuration() {
-    var durationGroup = $('#duration_group');
-    var durationField = durationGroup.find('#episode_duration');
-    var duration = durationField.val();
-    duration = +duration; //Coerce to a number for comparison purposes.
-    var helpBlock = durationGroup.find('#duration_help_block');
+function verifyEpisodeEndDateTime() {
 
-    if (duration === '') {
-        markEpisodeDurationMissing(durationGroup, helpBlock);
-        return false;
+    var startDateTimeField = $('#start_datetime');
+    var startDateTime = _getDateFromField(startDateTimeField);
+
+    var endDateTimeGroup = $('#end_datetime_group');
+    var endDateTimeField = endDateTimeGroup.find('#end_datetime');
+    var endDateTime = _getDateFromField(endDateTimeField);
+
+    var helpBlock = $('#end_datetime_help_block');
+
+
+    var minDuration = endDateTimeField.data('minDuration');
+    minDuration = +minDuration;
+
+    var earliestEnd = startDateTime.clone();
+    earliestEnd = earliestEnd.add(minDuration);
+    if (endDateTime.isBefore(earliestEnd)) {
+        markEpisodeDurationTooShort(endDateTimeGroup, helpBlock);
     }
 
-    var minDuration = durationField.attr('min');
-    minDuration = +minDuration;
-    var maxDuration = durationField.attr('max');
+
+    var maxDuration = endDateTimeField.data('maxDuration');
     maxDuration = +maxDuration;
 
-    if (duration < minDuration) {
-        markEpisodeDurationTooShort(durationGroup, helpBlock);
-        return false;
-
-    } else if (duration > maxDuration) {
-        markEpisodeDurationTooLong(durationGroup, helpBlock);
-        return false;
-
-    } else {
-        markEpisodeDurationCorrect(durationGroup, helpBlock);
-        return true;
+    var latestEnd = startDateTime.clone();
+    latestEnd = latestEnd.add(maxDuration);
+    if (endDateTime.isAfter(latestEnd)) {
+        markEpisodeDurationTooLong(endDateTimeGroup, helpBlock);
     }
 }
+
 
 function verifyPrerecordDate() {
     var prerecordGroup = $('#prerecord_group');
@@ -249,4 +253,9 @@ function _isEpisodeStartDatetimeValid(startDatetimeInput) {
     // check for two kinds of date format, based on browser used
     return moment(startDatetimeInput, "YYYY-MM-DDTHH:mm", true).isValid() ||
         moment(startDatetimeInput, "YYYY-MM-DDTHH:mm:ss", true).isValid();
+}
+
+function _getDateFromField(field) {
+    var dateString = field.val();
+    return moment(dateString);
 }

--- a/public_html/digital-logsheets/js/validation/episodeValidation.js
+++ b/public_html/digital-logsheets/js/validation/episodeValidation.js
@@ -30,7 +30,7 @@ function adjustPrerecordDateBounds(prerecordEarlyDaysLimit, prerecordLateDaysLim
     var episodeStartInput = $('#start_datetime');
     var episodeStartVal = episodeStartInput.val();
 
-    if (!_isEpisodeStartDatetimeValid(episodeStartVal)) {
+    if (!_isDateTimeValid(episodeStartVal)) {
         return;
     }
 
@@ -142,7 +142,7 @@ function verifyEpisodeStartDatetime() {
     var helpBlock = startDatetimeGroup.find('#start_datetime_help_block');
 
 
-    var isInputADate = _isEpisodeStartDatetimeValid(startDatetimeInput);
+    var isInputADate = _isDateTimeValid(startDatetimeInput);
 
     if (isInputADate) {
         var earlyLimit = startDatetimeInputField.attr("min");
@@ -183,6 +183,10 @@ function verifyEpisodeEndDateTime() {
 
     var helpBlock = $('#end_datetime_help_block');
 
+    if (!_isDateTimeValid(endDateTime)) {
+        markEndDateTimeMissing(endDateTimeGroup, helpBlock);
+        return false;
+    }
 
     var minDuration = endDateTimeField.data('minDuration');
     minDuration = +minDuration;
@@ -191,6 +195,7 @@ function verifyEpisodeEndDateTime() {
     earliestEnd = earliestEnd.add(minDuration);
     if (endDateTime.isBefore(earliestEnd)) {
         markEpisodeDurationTooShort(endDateTimeGroup, helpBlock);
+        return false;
     }
 
 
@@ -201,7 +206,11 @@ function verifyEpisodeEndDateTime() {
     latestEnd = latestEnd.add(maxDuration);
     if (endDateTime.isAfter(latestEnd)) {
         markEpisodeDurationTooLong(endDateTimeGroup, helpBlock);
+        return false;
     }
+
+    markEndDateTimeCorrect(endDateTimeGroup, helpBlock);
+    return true;
 }
 
 
@@ -249,7 +258,7 @@ function verifyPrerecordDate() {
     }
 }
 
-function _isEpisodeStartDatetimeValid(startDatetimeInput) {
+function _isDateTimeValid(startDatetimeInput) {
     // check for two kinds of date format, based on browser used
     return moment(startDatetimeInput, "YYYY-MM-DDTHH:mm", true).isValid() ||
         moment(startDatetimeInput, "YYYY-MM-DDTHH:mm:ss", true).isValid();

--- a/public_html/digital-logsheets/js/validation/markErrors.js
+++ b/public_html/digital-logsheets/js/validation/markErrors.js
@@ -71,8 +71,8 @@ function markEpisodeStartDatetimeTooFarInFuture(group, helpBlock) {
     markFieldError(group, helpBlock);
 }
 
-function markEpisodeDurationCorrect(group, helpBlock) {
-    var durationMissingMessage = $('#missing_duration_message');
+function markEndDateTimeCorrect(group, helpBlock) {
+    var durationMissingMessage = $('#missing_end_datetime_message');
     durationMissingMessage.addClass("hidden");
 
     var tooShortMessage = $('#too_short_message');
@@ -84,8 +84,8 @@ function markEpisodeDurationCorrect(group, helpBlock) {
     markFieldCorrect(group, helpBlock);
 }
 
-function markEpisodeDurationMissing(group, helpBlock) {
-    var durationMissingMessage = $('#missing_duration_message');
+function markEndDateTimeMissing(group, helpBlock) {
+    var durationMissingMessage = $('#missing_end_datetime_message');
     durationMissingMessage.removeClass("hidden");
 
     var tooShortMessage = $('#too_short_message');
@@ -98,7 +98,7 @@ function markEpisodeDurationMissing(group, helpBlock) {
 }
 
 function markEpisodeDurationTooShort(group, helpBlock) {
-    var durationMissingMessage = $('#missing_duration_message');
+    var durationMissingMessage = $('#missing_end_datetime_message');
     durationMissingMessage.addClass("hidden");
 
     var tooShortMessage = $('#too_short_message');
@@ -111,7 +111,7 @@ function markEpisodeDurationTooShort(group, helpBlock) {
 }
 
 function markEpisodeDurationTooLong(group, helpBlock) {
-    var durationMissingMessage = $('#missing_duration_message');
+    var durationMissingMessage = $('#missing_end_datetime_message');
     durationMissingMessage.addClass("hidden");
 
     var tooShortMessage = $('#too_short_message');

--- a/public_html/digital-logsheets/save-episode.php
+++ b/public_html/digital-logsheets/save-episode.php
@@ -36,6 +36,7 @@ $prerecord = isset($_POST['prerecord']);
 $prerecordDate = $_POST['prerecord_date'];
 
 $episodeStartTime = $_POST['start_datetime'];
+$episodeEndTime = $_POST['end_datetime'];
 $episodeDurationHours = $_POST['episode_duration'];
 $notes = $_POST['notes'];
 
@@ -52,10 +53,12 @@ try {
     $episodeStartTime = getDateTimeFromDateTimeString($episodeStartTime);
     $episodeObject->setStartTime($episodeStartTime);
 
-    if ($episodeStartTime != null) {
+    /*if ($episodeStartTime != null) {
         $episodeEndTime = computeEpisodeEndTime($episodeStartTime, $episodeDurationHours);
         $episodeObject->setEndTime($episodeEndTime);
-    }
+    }*/
+    $episodeEndTime = getDateTimeFromDateString($episodeEndTime);
+    $episodeObject->setEndTime($episodeEndTime);
 
     $episodeObject->setIsPrerecord($prerecord);
     $prerecordDate = getDateTimeFromDateString($prerecordDate);

--- a/public_html/digital-logsheets/save-episode.php
+++ b/public_html/digital-logsheets/save-episode.php
@@ -67,7 +67,7 @@ try {
     $episodeObject->setNotes($notes);
 
     $episodeValidator = new EpisodeValidator($episodeObject);
-    $episodeErrors = $episodeValidator->checkDraftSaveValidity($episodeDurationHours);
+    $episodeErrors = $episodeValidator->checkDraftSaveValidity();
 
     $doEpisodeErrorsExist = $episodeErrors->doErrorsExist();
     if ($doEpisodeErrorsExist) {

--- a/public_html/digital-logsheets/save-episode.php
+++ b/public_html/digital-logsheets/save-episode.php
@@ -37,7 +37,6 @@ $prerecordDate = $_POST['prerecord_date'];
 
 $episodeStartTime = $_POST['start_datetime'];
 $episodeEndTime = $_POST['end_datetime'];
-$episodeDurationHours = $_POST['episode_duration'];
 $notes = $_POST['notes'];
 
 session_start();
@@ -53,11 +52,7 @@ try {
     $episodeStartTime = getDateTimeFromDateTimeString($episodeStartTime);
     $episodeObject->setStartTime($episodeStartTime);
 
-    /*if ($episodeStartTime != null) {
-        $episodeEndTime = computeEpisodeEndTime($episodeStartTime, $episodeDurationHours);
-        $episodeObject->setEndTime($episodeEndTime);
-    }*/
-    $episodeEndTime = getDateTimeFromDateString($episodeEndTime);
+    $episodeEndTime = getDateTimeFromDateTimeString($episodeEndTime);
     $episodeObject->setEndTime($episodeEndTime);
 
     $episodeObject->setIsPrerecord($prerecord);


### PR DESCRIPTION
After conversation with station staff, the project developers and station staff concluded that a significant portion of all episodes (20-40%, estimated) are not rounded to the nearest hour or half hour, as originally determined. Instead, they are a few minutes short of a round number (e.g., 58 minutes, 119 minutes).

Episodes with non-round durations would be difficult to enter using an integer denoting the number of hours. For instance, 58 minutes translates to 0.9667 hours. 

Also in our later discussions with station staff, it became clear that each episode (except the earliest and latest on record) needs to start as the previous episode ends and end as the next episode starts. In other words, there can be no period of time not accounted for by the collection of all episodes.

Considering the reasons above, we decided to only allow the user to enter an endtime. This should encourage programmers to enter the exact time their episodes end instead of opting for the easier method of entering a round duration number.