### PR TITLE
Show category description in a tooltip

### DIFF
--- a/digital-logsheets-res/templates/add-segments.tpl
+++ b/digital-logsheets-res/templates/add-segments.tpl
@@ -38,6 +38,7 @@
             getEpisodeSegments();
             setFormOnSubmitBehaviour();
             setFocusOutBehaviour();
+            $('[data-toggle="tooltip"]').tooltip();
         }
 
 
@@ -93,6 +94,7 @@
 <body onload="init()">
 <div class="container-fluid">
     <div class="col-md-8">
+
         <h3>Add Segments</h3>
 
         <h5>Episode Information:</h5>

--- a/digital-logsheets-res/templates/segment-form.tpl
+++ b/digital-logsheets-res/templates/segment-form.tpl
@@ -14,17 +14,18 @@
 
         <div class="form-group">
             <label for="category" class="control-label">Category:</label>
-            <div class="btn-group category" data-toggle="buttons">
-                <label class="btn btn-primary" onclick="setupCat1Fields()">
+            <div class="btn-group" class="category" id="category" data-toggle="buttons">
+                <label class="btn btn-primary" onclick="setupCat1Fields()" data-toggle="tooltip" data-placement="bottom" title="All Spoken Word">
                     <input type="radio" name="category" class="category1" autocomplete="off" required value="1">1</label>
-                <label class="btn btn-primary" onclick="setupCat2Fields()">
+                <label class="btn btn-primary" onclick="setupCat2Fields()" data-toggle="tooltip" data-placement="bottom" title="General Music">
                     <input type="radio" name="category" class="category2" autocomplete="off" value="2">2</label>
-                <label class="btn btn-primary" onclick="setupCat3Fields()">
+                <label class="btn btn-primary" onclick="setupCat3Fields()" data-toggle="tooltip" data-placement="bottom" title="Jazz, Classical, and Traditional Music">
                     <input type="radio" name="category" class="category3" autocomplete="off" value="3">3</label>
-                <label class="btn btn-primary" onclick="setupCat4Fields()">
+                <label class="btn btn-primary" onclick="setupCat4Fields()" data-toggle="tooltip" data-placement="bottom" title="Musical Productions (ID's, etc.)">
                     <input type="radio" name="category" class="category4" autocomplete="off" value="4">4</label>
-                <label class="btn btn-primary" onclick="setupCat5Fields()">
-                    <input type="radio" name="category" class="category5" autocomplete="off" value="5">5</label></div>
+                <label class="btn btn-primary" onclick="setupCat5Fields()" data-toggle="tooltip" data-placement="bottom" title="Ads, Promos">
+                    <input type="radio" name="category" class="category5" autocomplete="off" value="5">5</label>
+            </div>
         </div>
 
         <div class="form-group row ad_number_group" style="display:none;">

--- a/digital-logsheets-res/templates/segment-form.tpl
+++ b/digital-logsheets-res/templates/segment-form.tpl
@@ -14,7 +14,7 @@
 
         <div class="form-group">
             <label for="category" class="control-label">Category:</label>
-            <div class="btn-group" class="category" id="category" data-toggle="buttons">
+            <div class="btn-group" class="category" id="category" data-toggle="buttons"> {*Need double class attribute for Bootstrap tooltip to work correctly*}
                 <label class="btn btn-primary" onclick="setupCat1Fields()" data-toggle="tooltip" data-placement="bottom" title="All Spoken Word">
                     <input type="radio" name="category" class="category1" autocomplete="off" required value="1">1</label>
                 <label class="btn btn-primary" onclick="setupCat2Fields()" data-toggle="tooltip" data-placement="bottom" title="General Music">


### PR DESCRIPTION
CRTC categories are represented by a number 1-5. To save space, we display categories as numbers; however, not all programmers know the meaning of each category from its number alone. This feature adds a tooltip for each category button that displays that category's meaning.