### PR TITLE
Confirm delete segment modal

### DIFF
--- a/digital-logsheets-res/templates/add-segments.tpl
+++ b/digital-logsheets-res/templates/add-segments.tpl
@@ -38,6 +38,7 @@
             getEpisodeSegments();
             setFormOnSubmitBehaviour();
             setFocusOutBehaviour();
+            setConfirmModalBehaviour();
         }
 
 
@@ -88,6 +89,25 @@
                                 {$episode|json_encode});
                     });
         }
+
+        function setConfirmModalBehaviour() {
+            $('#confirmDeleteModal')
+                .on('show.bs.modal', function (e) {
+                    var deleteSegmentLink = $(e.relatedTarget);
+                    var deleteSegmentRow = deleteSegmentLink.closest("tr");
+
+                    var segmentToDelete = deleteSegmentRow.data("segment");
+                    var segmentIdToDelete = segmentToDelete.id;
+
+                    var confirmDeleteButton = $("#confirmDeleteButton");
+
+                    confirmDeleteButton.click(function (e) {
+                        e.preventDefault();
+                        deleteEpisodeSegment(segmentIdToDelete);
+                        $('#confirmDeleteModal').modal('hide');
+                    });
+                });
+        }
     </script>
 </head>
 <body onload="init()">
@@ -134,6 +154,24 @@
 
                 </tbody>
             </table>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="confirmDeleteModal" tabindex="-1" role="dialog" aria-labelledby="confirmDeleteModalLabel">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="confirmDeleteModalLabel">Warning</h4>
+            </div>
+            <div class="modal-body">
+                Are you sure you want to delete this segment?
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" id="confirmDeleteButton" onClick="">Yes</button>
+                <button type="button" class="btn btn-primary" data-dismiss="modal">No</button>
+            </div>
         </div>
     </div>
 </div>

--- a/public_html/digital-logsheets/js/editSegment.js
+++ b/public_html/digital-logsheets/js/editSegment.js
@@ -19,7 +19,7 @@
  */
 
 function prepareFormForEdit(eventObject) {
-    var tableRow = $(eventObject.target).parent().parent().parent().parent();
+    var tableRow = $(eventObject.target).closest("tr");
     var segment_object = $(tableRow).data("segment");
 
     showEditForm();

--- a/public_html/digital-logsheets/js/ui/segmentOptionsMenu.js
+++ b/public_html/digital-logsheets/js/ui/segmentOptionsMenu.js
@@ -19,11 +19,9 @@
  */
 
 function generateDeleteButton(segment_id) {
-    return $(document.createElement("li"))
-        .click(function(eventObject) {
-            deleteEpisodeSegment(segment_id);
-        })
-        .append('<a href="#">Delete</a>');
+    var li =  $(document.createElement("li"));
+    li.append('<a href="#" data-toggle="modal" data-target="#confirmDeleteModal">Delete</a>');
+    return li;
 }
 
 function generateEditButton(segment_id) {

--- a/public_html/digital-logsheets/js/ui/segmentOptionsMenu.js
+++ b/public_html/digital-logsheets/js/ui/segmentOptionsMenu.js
@@ -23,7 +23,7 @@ function generateDeleteButton(segment_id) {
         .click(function(eventObject) {
             deleteEpisodeSegment(segment_id);
         })
-        .text("Delete");
+        .append('<a href="#">Delete</a>');
 }
 
 function generateEditButton(segment_id) {
@@ -31,5 +31,5 @@ function generateEditButton(segment_id) {
         .click(function(eventObject) {
             prepareFormForEdit(eventObject);
         })
-        .text("Edit");
+        .append('<a href="#">Edit</a>');
 }


### PR DESCRIPTION
When the user attempts to delete an already-entered segment, a modal (essentially a pop-up window that appears over the application) asks the user to confirm they want to delete the segment. This prevents accidental segment deletions and ensuing user frustration.

Also in these commits, UI polishing for the segment options (edit or delete) dropdown for already-entered segments.