### PR TITLE
Fix require paths to files in parent folders

### DIFF
--- a/digital-logsheets-res/php/database/manageEpisodeEntries.php
+++ b/digital-logsheets-res/php/database/manageEpisodeEntries.php
@@ -22,7 +22,7 @@
 include_once("readFromDatabase.php");
     include_once("writeToDatabase.php");
     include_once("formatDateStrings.php");
-    include_once(__DIR__ . "/../objects/logsheetClasses.php");
+    include_once(__DIR__ . "../objects/logsheetClasses.php");
 
 
     class manageEpisodeEntries {

--- a/digital-logsheets-res/php/database/managePlaylistEntries.php
+++ b/digital-logsheets-res/php/database/managePlaylistEntries.php
@@ -21,7 +21,7 @@
 
 include_once("readFromDatabase.php");
     include_once("writeToDatabase.php");
-    include_once(__DIR__ . "/../objects/logsheetClasses.php");
+    include_once(__DIR__ . "../objects/logsheetClasses.php");
 
     class managePlaylistEntries {
 

--- a/digital-logsheets-res/php/database/manageSegmentEntries.php
+++ b/digital-logsheets-res/php/database/manageSegmentEntries.php
@@ -22,7 +22,7 @@
 include_once("readFromDatabase.php");
     include_once("writeToDatabase.php");
     include_once("managePlaylistEntries.php");
-    include_once(__DIR__ . "/../objects/Segment.php");
+    include_once(__DIR__ . "../objects/Segment.php");
 
     class manageSegmentEntries {
 

--- a/digital-logsheets-res/php/objects/Archive.php
+++ b/digital-logsheets-res/php/objects/Archive.php
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-require_once(__DIR__ . "/../database/manageEpisodeEntries.php");
+require_once(__DIR__ . "../database/manageEpisodeEntries.php");
     class Archive {
 
         private $db;

--- a/digital-logsheets-res/php/objects/Category.php
+++ b/digital-logsheets-res/php/objects/Category.php
@@ -19,8 +19,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-include_once(__DIR__ . "/../database/manageCategoryEntries.php");
-    include_once(__DIR__ . "/../validator/CategoryValidator.php");
+include_once(__DIR__ . "../database/manageCategoryEntries.php");
+    include_once(__DIR__ . "../validator/CategoryValidator.php");
     class Category extends LogsheetComponent {
 
         private $name;

--- a/digital-logsheets-res/php/objects/Episode.php
+++ b/digital-logsheets-res/php/objects/Episode.php
@@ -20,8 +20,8 @@
  */
 
     //TODO: Error checking...
-    require_once(__DIR__ . "/../database/manageEpisodeEntries.php");
-    require_once(__DIR__ . "/LogsheetComponent.php");
+    require_once(__DIR__ . "../database/manageEpisodeEntries.php");
+    require_once(__DIR__ . "LogsheetComponent.php");
 
     class Episode extends LogsheetComponent {
 

--- a/digital-logsheets-res/php/objects/Playlist.php
+++ b/digital-logsheets-res/php/objects/Playlist.php
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-require_once(__DIR__ . "/../database/managePlaylistEntries.php");
+require_once(__DIR__ . "../database/managePlaylistEntries.php");
 
     class Playlist extends LogsheetComponent {
         /**

--- a/digital-logsheets-res/php/objects/Program.php
+++ b/digital-logsheets-res/php/objects/Program.php
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-include_once(__DIR__ . "/../database/manageProgramEntries.php");
+include_once(__DIR__ . "../database/manageProgramEntries.php");
     class Program extends LogsheetComponent{
 
         /**

--- a/digital-logsheets-res/php/objects/Segment.php
+++ b/digital-logsheets-res/php/objects/Segment.php
@@ -19,8 +19,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-include_once(__DIR__ . "/../database/manageSegmentEntries.php");
-    include_once(__DIR__ . "/../validator/SegmentValidator.php");
+include_once(__DIR__ . "../database/manageSegmentEntries.php");
+    include_once(__DIR__ . "../validator/SegmentValidator.php");
 
     class Segment extends LogsheetComponent implements JsonSerializable{
 


### PR DESCRIPTION
Previously, some of these paths began with a slash. This could be read
by the server as the path starting from the root instead of starting
from the parent folder.