### PR TITLE
Handle string and non-existent episode ID parameter

### DIFF
--- a/digital-logsheets-res/php/DataPreparationForUI.php
+++ b/digital-logsheets-res/php/DataPreparationForUI.php
@@ -46,10 +46,19 @@ function getSelect2ProgramsList($db) {
  */
 function getFormSubmissionArray($episode) {
 
+    $program = $episode->getProgram();
+    $programId = null;
+    $programName = null;
+
+    if ($program) {
+        $programId = $program->getId();
+        $programName = $program->getName();
+    }
+
     return array(
         'programmer' => $episode->getProgrammer(),
-        'programId' => $episode->getProgram()->getId(),
-        'programName' => $episode->getProgram()->getName(),
+        'programId' => $programId,
+        'programName' => $programName,
         'startDatetime' => formatDatetimeForHTML($episode->getStartTime()),
         'endDatetime' => formatDatetimeForHTML($episode->getEndTime()),
         'prerecord' => $episode->isPrerecord(),

--- a/digital-logsheets-res/php/database/manageEpisodeEntries.php
+++ b/digital-logsheets-res/php/database/manageEpisodeEntries.php
@@ -64,7 +64,8 @@
          * @param Episode $episodeObject
          */
         public static function getEpisodeAttributesFromDatabase($dbConn, $episodeId, $episodeObject) {
-            $databaseResults = readFromDatabase::readFilteredColumnFromTable($dbConn, null, self::TABLE_NAME, array(self::ID_COLUMN_NAME), array($episodeId));
+            $databaseResults = readFromDatabase::readFilteredColumnFromTable($dbConn, null,
+                self::TABLE_NAME, array(self::ID_COLUMN_NAME), array($episodeId));
             $databaseResults = $databaseResults[0];
 
             $programId = $databaseResults[self::PROGRAM_COLUMN_NAME];
@@ -99,7 +100,8 @@
         }
 
         public static function getAllEpisodesFromDatabase($dbConn) {
-            $episodeIds = readFromDatabase::readEntireColumnFromTable($dbConn, array(self::ID_COLUMN_NAME), self::TABLE_NAME);
+            $episodeIds = readFromDatabase::readEntireColumnFromTable($dbConn, array(self::ID_COLUMN_NAME),
+                self::TABLE_NAME);
 
             return self::buildEpisodeObjectsFromIds($dbConn, $episodeIds);
         }

--- a/public_html/new-logsheet.php
+++ b/public_html/new-logsheet.php
@@ -72,7 +72,7 @@ $draftEpisodeId = $_GET['draftEpisodeId'];
         if (isset($formSubmission)) {
             $smarty->assign("formSubmission", $formSubmission);
 
-        } else if (isset($draftEpisodeId)) {
+        } else if (isset($draftEpisodeId) && $draftEpisodeId) {
             $draftEpisode = new Episode($db, $draftEpisodeId);
             $draftEpisodeArray = getFormSubmissionArray($draftEpisode);
             $smarty->assign("formSubmission", $draftEpisodeArray);


### PR DESCRIPTION
In the "episode metadata" phase of the log sheet entry process, a parameter is passed to determine whether a user is editing the metadata of an existing episode or attempting to create a new episode. If this parameter is deformed or otherwise invalid, the system now assumes the user would like to create a new episode.