### PR TITLE
Improve compatibility with Safari and Firefox browsers

### DIFF
--- a/digital-logsheets-res/templates/add-segments.tpl
+++ b/digital-logsheets-res/templates/add-segments.tpl
@@ -4,6 +4,7 @@
     <title>New Logsheet</title>
 
     {include './header.tpl'}
+    
     <script type="text/javascript">
         function getEpisodeStartTime() {
             return {$episode.startTime|json_encode};
@@ -19,170 +20,91 @@
     <script type="text/javascript" src="js/ui/segmentOptionsMenu.js"></script>
     <script type="text/javascript" src="js/saveReceiveSegments.js"></script>
     <script type="text/javascript" src="js/ui/categoryButton.js"></script>
-    <script type="text/javascript">
-
-        function init() {
-            getEpisodeSegments();
-            setFormOnSubmitBehaviour();
-            setFocusOutBehaviour();
-            setConfirmModalBehaviour();
-            $('[data-toggle="tooltip"]').tooltip();
-        }
-
-
-        function setFormOnSubmitBehaviour() {
-            var episode = {$episode|json_encode};
-
-            $('#logsheet').on('submit', function(e) {
-                e.preventDefault();
-                createSegment();
-            });
-
-            var logsheetEdit = $('#logsheet_edit');
-
-            logsheetEdit.on('submit', function(e) {
-                e.preventDefault();
-                editEpisodeSegment();
-            });
-
-            logsheetEdit.hide();
-
-            $('#finalize')
-                    .on('submit', function(e) {
-                        if (!verifyPlaylistEpisodeAlignment()) {
-                            e.preventDefault();
-
-                        }
-
-                        $('#added_segments').find('tbody').find('tr').each(function (i, segment) {
-                            segment = $(segment);
-                            var errors = segment.data("errors");
-
-                            if (isSegmentErroneous(errors)) {
-                                markErroneousSegmentsExist();
-                                e.preventDefault();
-                                return false;
-                            }
-
-                            markNoErroneousSegmentsExist();
-                        });
-                    });
-        }
-
-        function setFocusOutBehaviour() {
-            var segmentTimeInput = $('.segment_time');
-
-            segmentTimeInput
-                    .focusout(function(e) {
-                        var segmentTimeField = $(e.delegateTarget);
-                        var timeGroup = segmentTimeField.parent().parent();
-
-                        verifySegmentStartTime(timeGroup,
-                                {$episode|json_encode});
-                    });
-        }
-
-        function setConfirmModalBehaviour() {
-            $('#confirmDeleteModal')
-                .on('show.bs.modal', function (e) {
-                    var deleteSegmentLink = $(e.relatedTarget);
-                    var deleteSegmentRow = deleteSegmentLink.closest("tr");
-
-                    var segmentToDelete = deleteSegmentRow.data("segment");
-                    var segmentIdToDelete = segmentToDelete.id;
-
-                    var confirmDeleteButton = $("#confirmDeleteButton");
-
-                    confirmDeleteButton.click(function (e) {
-                        e.preventDefault();
-                        deleteEpisodeSegment(segmentIdToDelete);
-                        $('#confirmDeleteModal').modal('hide');
-                    });
-                });
-        }
-    </script>
+    <script type="text/javascript" src="js/init/add-segments.js"></script>
 </head>
+
+
 <body onload="init()">
-<div class="container-fluid">
-    <div class="col-md-7">
+    <div class="container-fluid">
+        <div class="col-md-7">
 
-        <h3>Add Segments</h3>
+            <h3>Add Segments</h3>
 
-        <h5>Episode Information:</h5>
-        Program:  {$episode.program} <br/>
-        Start Date/Time: {$episode.startDatetime} <br/>
-        End Date/Time: {$episode.endDatetime} <br/> <br/>
+            <h5>Episode Information:</h5>
+            Program:  {$episode.program} <br/>
+            Start Date/Time: {$episode.startDatetime} <br/>
+            End Date/Time: {$episode.endDatetime} <br/> <br/>
 
 
-        {include file='./segment-form.tpl' idSuffix=''}
-        {include file='./segment-form.tpl' idSuffix='_edit'}
+            {include file='./segment-form.tpl' idSuffix=''}
+            {include file='./segment-form.tpl' idSuffix='_edit'}
+
+            <br />
+
+            <form id="finalize" class="forward_form" role="form" action="review-logsheet.php" method="get" onsubmit="">
+                <input type="hidden" name="epId" value={$episode.id|json_encode}>
+                <input type="submit" value="Final Review">
+            </form>
+
+            <form class="backward_form" action="new-logsheet.php" method="get">
+                <input type="hidden" name="epId" value="{$episode.id}"/>
+                <input type="submit" value="Back to Episode Metadata"/>
+            </form>
+        </div>
 
         <br />
+        <br />
 
-        <form id="finalize" class="forward_form" role="form" action="review-logsheet.php" method="get" onsubmit="">
-            <input type="hidden" name="epId" value={$episode.id|json_encode}>
-            <input type="submit" value="Final Review">
-        </form>
+        <div class="col-md-5">
+            <span id="playlist_not_aligned_help_text" class="help-block{if !isset($formErrors.noAlignmentWithEpisodeStart)} hidden{/if}">
+                The earliest segment must align with the episode start date/time.
+            </span>
 
-        <form class="backward_form" action="new-logsheet.php" method="get">
-            <input type="hidden" name="epId" value="{$episode.id}"/>
-            <input type="submit" value="Back to Episode Metadata"/>
-        </form>
-    </div>
+            <span id="segment_errors_exist_help_text" class="help-block{if !isset($formErrors.erroneousSegmentsExist)} hidden{/if}">
+                Errors exist in the highlighted segments below. Please correct them before proceeding to the final review.
+            </span>
 
-    <br />
-    <br />
+            <div class="panel panel-default">
+                <div class="panel-heading">Episode Segments</div>
 
-    <div class="col-md-5">
-        <span id="playlist_not_aligned_help_text" class="help-block{if !isset($formErrors.noAlignmentWithEpisodeStart)} hidden{/if}">
-            The earliest segment must align with the episode start date/time.
-        </span>
-
-        <span id="segment_errors_exist_help_text" class="help-block{if !isset($formErrors.erroneousSegmentsExist)} hidden{/if}">
-            Errors exist in the highlighted segments below. Please correct them before proceeding to the final review.
-        </span>
-
-        <div class="panel panel-default">
-            <div class="panel-heading">Episode Segments</div>
-
-            <table class="table table-hover" id="added_segments">
-                <colgroup>
-                    <col id="start_time_column" />
-                    <col span="3"/>
-                    <col />
-                </colgroup>
-                <thead>
+                <table class="table table-hover" id="added_segments">
+                    <colgroup>
+                        <col id="start_time_column" />
+                        <col span="3"/>
+                        <col />
+                    </colgroup>
+                    <thead>
                     <tr>
                         <th>Time</th>
                         <th colspan="3">Description</th>
                         <th>Category</th>
                         <th></th>
                     </tr>
-                </thead>
-                <tbody>
+                    </thead>
+                    <tbody>
 
-                </tbody>
-            </table>
-        </div>
-    </div>
-</div>
-
-<div class="modal fade" id="confirmDeleteModal" tabindex="-1" role="dialog" aria-labelledby="confirmDeleteModalLabel">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <h4 class="modal-title" id="confirmDeleteModalLabel">Warning</h4>
-            </div>
-            <div class="modal-body">
-                Are you sure you want to delete this segment?
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-default" id="confirmDeleteButton" onClick="">Yes</button>
-                <button type="button" class="btn btn-primary" data-dismiss="modal">No</button>
+                    </tbody>
+                </table>
             </div>
         </div>
     </div>
-</div>
+
+    <div class="modal fade" id="confirmDeleteModal" tabindex="-1" role="dialog" aria-labelledby="confirmDeleteModalLabel">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title" id="confirmDeleteModalLabel">Warning</h4>
+                </div>
+                <div class="modal-body">
+                    Are you sure you want to delete this segment?
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" id="confirmDeleteButton" onClick="">Yes</button>
+                    <button type="button" class="btn btn-primary" data-dismiss="modal">No</button>
+                </div>
+            </div>
+        </div>
+    </div>
 </body>
 </html>

--- a/digital-logsheets-res/templates/add-segments.tpl
+++ b/digital-logsheets-res/templates/add-segments.tpl
@@ -4,7 +4,7 @@
     <title>New Logsheet</title>
 
     {include './header.tpl'}
-    
+
     <script type="text/javascript">
         function getEpisodeStartTime() {
             return {$episode.startTime|json_encode};
@@ -12,6 +12,8 @@
     </script>
 
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.14.1/moment.min.js"></script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-timepicker/0.5.2/css/bootstrap-timepicker.min.css" rel="stylesheet">
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-timepicker/0.5.2/js/bootstrap-timepicker.min.js"></script>
     <script type="text/javascript" src="js/validation/markErrors.js"></script>
     <script type="text/javascript" src="js/validation/segmentValidation.js"></script>
     <script type="text/javascript" src="js/validation/playlistValidation.js"></script>

--- a/digital-logsheets-res/templates/add-segments.tpl
+++ b/digital-logsheets-res/templates/add-segments.tpl
@@ -12,8 +12,9 @@
     </script>
 
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.14.1/moment.min.js"></script>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-timepicker/0.5.2/css/bootstrap-timepicker.min.css" rel="stylesheet">
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-timepicker/0.5.2/js/bootstrap-timepicker.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.17.47/js/bootstrap-datetimepicker.min.js"></script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.17.47/css/bootstrap-datetimepicker.min.css"
+          rel="stylesheet"/>
     <script type="text/javascript" src="js/validation/markErrors.js"></script>
     <script type="text/javascript" src="js/validation/segmentValidation.js"></script>
     <script type="text/javascript" src="js/validation/playlistValidation.js"></script>

--- a/digital-logsheets-res/templates/logsheet-template.tpl
+++ b/digital-logsheets-res/templates/logsheet-template.tpl
@@ -24,7 +24,7 @@ Pre-recorded? {$episode.prerecorded}  Date? {$episode.prerecordDate} <br/> <br/>
             {if $segment.category == 2 || $segment.category == 3}
                 <td>{$segment.name}</td>
                 <td>{$segment.album}</td>
-                <td>{$segment.artist}</td>
+                <td>{$segment.author}</td>
             {elseif $segment.category == 5}
                 <td colspan="3">{$segment.adNumber}</td>
             {else}
@@ -32,9 +32,9 @@ Pre-recorded? {$episode.prerecorded}  Date? {$episode.prerecordDate} <br/> <br/>
             {/if}
 
             <td>{$segment.category}</td>
-            <td>{$segment.canCon}</td>
-            <td>{$segment.newRelease}</td>
-            <td>{$segment.frenchVocalMusic}</td>
+            <td>{if $segment.canCon == 1}&#x2713{/if}</td>
+            <td>{if $segment.newRelease == 1}&#x2713{/if}</td>
+            <td>{if $segment.frenchVocalMusic == 1}&#x2713{/if}</td>
         </tr>
     {/foreach}
 </table>

--- a/digital-logsheets-res/templates/new-logsheet.tpl
+++ b/digital-logsheets-res/templates/new-logsheet.tpl
@@ -75,6 +75,9 @@
 
             $('#start_datetime').datetimepicker();
             $('#end_datetime').datetimepicker();
+            $('#prerecord_date').datetimepicker({
+                format: "L"
+            });
         }
     </script>
 </head>
@@ -206,7 +209,7 @@
                         <input type="checkbox" id="prerecord" title="Was episode prerecorded?" name="prerecord"
                                aria-label="Was episode prerecorded?"{if $formSubmission.prerecord} checked{/if}>
                     </span>
-                        <input class="form-control" type="date"
+                        <input class="form-control" type="text"
                                name="prerecord_date" id="prerecord_date"
                                aria-label="Prerecord date"
                                value="{$formSubmission.prerecordDate}" disabled>

--- a/digital-logsheets-res/templates/new-logsheet.tpl
+++ b/digital-logsheets-res/templates/new-logsheet.tpl
@@ -13,9 +13,7 @@
 
     <link href="css/custom.css" rel="stylesheet"/>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.14.1/moment.min.js"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.17.47/js/bootstrap-datetimepicker.min.js"></script>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.17.47/css/bootstrap-datetimepicker.min.css"
-          rel="stylesheet"/>
+
     <script src="js/validation/markErrors.js"></script>
     <script src="js/validation/episodeValidation.js"></script>
     <script src="js/ui/prerecord.js"></script>

--- a/digital-logsheets-res/templates/new-logsheet.tpl
+++ b/digital-logsheets-res/templates/new-logsheet.tpl
@@ -13,12 +13,21 @@
 
     <link href="css/custom.css" rel="stylesheet"/>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.14.1/moment.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.17.47/js/bootstrap-datetimepicker.min.js"></script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.17.47/css/bootstrap-datetimepicker.min.css"
+          rel="stylesheet"/>
     <script src="js/validation/markErrors.js"></script>
     <script src="js/validation/episodeValidation.js"></script>
     <script src="js/ui/prerecord.js"></script>
     <script src="js/ui/categoryButton.js"></script>
     <script type="text/javascript">
         function init() {
+            var data = {$programs};
+
+            $(".program").select2({
+                data: data
+            });
+
             setupEpisodeValidation({
                 episodeStartEarlyLimit: {$episodeStartEarlyLimit|json_encode},
                 episodeStartLateLimit: {$episodeStartLateLimit|json_encode},
@@ -64,12 +73,8 @@
                 }
             });
 
-
-            var data = {$programs};
-
-            $(".program").select2({
-                data: data
-            });
+            $('#start_datetime').datetimepicker();
+            $('#end_datetime').datetimepicker();
         }
     </script>
 </head>
@@ -138,7 +143,7 @@
             <div id="start_datetime_group" class="form-group row{if $startDatetimeError} has-error{/if}">
                 <div class="col-md-6 col-sm-6">
                     <label for="start_datetime" class="control-label">Start Date/Time:</label>
-                    <input class="form-control" type="datetime-local"
+                    <input class="form-control" type="text"
                            name="start_datetime" id="start_datetime" step="60"
                            value="{$formSubmission.startDatetime}" required>
                     <span id="start_datetime_help_block" class="help-block{if !$startDatetimeError} hidden{/if}">
@@ -146,10 +151,10 @@
                             Please enter a valid start date/time.
                         </span>
                         <span id="air_date_too_far_in_past_message" class="{if !$formErrors.airDateTooFarInPast}hidden{/if}">
-                            Start date/time must be after {$episodeStartEarlyLimit}.
+                            Start date/time must be after {$episodeStartEarlyLimit|date_format:"%m/%d/%Y %l:%M"}.
                         </span>
                         <span id="air_date_too_far_in_future_message" class="{if !$formErrors.airDateTooFarInFuture}hidden{/if}">
-                            Start date/time must be before {$episodeStartLateLimit}.
+                            Start date/time must be before {$episodeStartLateLimit|date_format:"%m/%d/%Y %l:%M"}.
                         </span>
                     </span>
                 </div>
@@ -167,7 +172,7 @@
             <div id="end_datetime_group" class="form-group row{if $endDateTimeError} has-error{/if}">
                 <div class="col-md-6 col-sm-6">
                     <label for="end_datetime" class="control-label">End Date/Time:</label>
-                    <input class="form-control" type="datetime-local"
+                    <input class="form-control" type="text"
                            name="end_datetime" id="end_datetime" step="60"
                            value="{$formSubmission.endDatetime}" required>
                     <span id="end_datetime_help_block" class="help-block{if !$endDateTimeError} hidden{/if}">

--- a/digital-logsheets-res/templates/segment-form.tpl
+++ b/digital-logsheets-res/templates/segment-form.tpl
@@ -5,7 +5,7 @@
             <div class="col-md-3">
                 <label for="segment_time{$idSuffix}" class="control-label">Time:</label>
                 <input name="segment_time" class="form-control segment_time"
-                       type="time" id="segment_time{$idSuffix}">
+                       type="text" id="segment_time{$idSuffix}">
                 <span id="segment_time_out_of_bounds_help_text{$idSuffix}" class="segment_time_help_text help-block hidden">
                     Segment must fall within episode.
                 </span>

--- a/public_html/js/init/add-segments.js
+++ b/public_html/js/init/add-segments.js
@@ -2,8 +2,13 @@ function init() {
     getEpisodeSegments();
     setFormOnSubmitBehaviour();
     setConfirmModalBehaviour();
-    $('#segment_time').timepicker();
-    $('#segment_time_edit').timepicker();
+
+    var options = {
+        format: "LT"
+    };
+
+    $('#segment_time').datetimepicker(options);
+    $('#segment_time_edit').datetimepicker(options);
     $('[data-toggle="tooltip"]').tooltip();
 }
 

--- a/public_html/js/init/add-segments.js
+++ b/public_html/js/init/add-segments.js
@@ -1,0 +1,62 @@
+function init() {
+    getEpisodeSegments();
+    setFormOnSubmitBehaviour();
+    setConfirmModalBehaviour();
+    $('[data-toggle="tooltip"]').tooltip();
+}
+
+function setFormOnSubmitBehaviour() {
+    $('#logsheet').on('submit', function(e) {
+        e.preventDefault();
+        createSegment();
+    });
+
+    var logsheetEdit = $('#logsheet_edit');
+
+    logsheetEdit.on('submit', function(e) {
+        e.preventDefault();
+        editEpisodeSegment();
+    });
+
+    logsheetEdit.hide();
+
+    $('#finalize')
+        .on('submit', function(e) {
+            if (!verifyPlaylistEpisodeAlignment()) {
+                e.preventDefault();
+
+            }
+
+            $('#added_segments').find('tbody').find('tr').each(function (i, segment) {
+                segment = $(segment);
+                var errors = segment.data("errors");
+
+                if (isSegmentErroneous(errors)) {
+                    markErroneousSegmentsExist();
+                    e.preventDefault();
+                    return false;
+                }
+
+                markNoErroneousSegmentsExist();
+            });
+        });
+}
+
+function setConfirmModalBehaviour() {
+    $('#confirmDeleteModal')
+        .on('show.bs.modal', function (e) {
+            var deleteSegmentLink = $(e.relatedTarget);
+            var deleteSegmentRow = deleteSegmentLink.closest("tr");
+
+            var segmentToDelete = deleteSegmentRow.data("segment");
+            var segmentIdToDelete = segmentToDelete.id;
+
+            var confirmDeleteButton = $("#confirmDeleteButton");
+
+            confirmDeleteButton.click(function (e) {
+                e.preventDefault();
+                deleteEpisodeSegment(segmentIdToDelete);
+                $('#confirmDeleteModal').modal('hide');
+            });
+        });
+}

--- a/public_html/js/init/add-segments.js
+++ b/public_html/js/init/add-segments.js
@@ -2,6 +2,8 @@ function init() {
     getEpisodeSegments();
     setFormOnSubmitBehaviour();
     setConfirmModalBehaviour();
+    $('#segment_time').timepicker();
+    $('#segment_time_edit').timepicker();
     $('[data-toggle="tooltip"]').tooltip();
 }
 

--- a/public_html/js/saveReceiveSegments.js
+++ b/public_html/js/saveReceiveSegments.js
@@ -109,9 +109,16 @@ function receiveSegmentsSuccess(data) {
             var segment_id = segment.id;
             var start_time = segment.startTime;
 
-            var name = getAbbreviatedString(segment.name);
-            var album = getAbbreviatedString(segment.album);
-            var author = getAbbreviatedString(segment.author);
+
+            var name = segment.name;
+            var album = segment.album;
+            var author = segment.author;
+
+            if (segment.category == 2 || segment.category == 3) {
+                name = getAbbreviatedString(name);
+                album = getAbbreviatedString(segment.album);
+                author = getAbbreviatedString(segment.author);
+            }
 
 
 

--- a/public_html/js/validation/episodeValidation.js
+++ b/public_html/js/validation/episodeValidation.js
@@ -275,9 +275,10 @@ function verifyPrerecordDate() {
 }
 
 function _isDateTimeValid(startDatetimeInput) {
-    // check for two kinds of date format, based on browser used
+    // check for multiple kinds of date format, depending on browser used
     return moment(startDatetimeInput, "YYYY-MM-DDTHH:mm", true).isValid() ||
-        moment(startDatetimeInput, "YYYY-MM-DDTHH:mm:ss", true).isValid();
+        moment(startDatetimeInput, "YYYY-MM-DDTHH:mm:ss", true).isValid() ||
+        moment(startDatetimeInput, "MM/DD/YYYY h:mm A", true).isValid();
 }
 
 function _getDateFromField(field) {

--- a/public_html/js/validation/episodeValidation.js
+++ b/public_html/js/validation/episodeValidation.js
@@ -244,7 +244,7 @@ function verifyPrerecordDate() {
     var prerecordDateField = prerecordGroup.find('#prerecord_date');
     var prerecordDate = prerecordDateField.val();
 
-    var isInputADate = moment(prerecordDate, "YYYY-MM-DD", true).isValid();
+    var isInputADate = _isDateValid(prerecordDate);
 
     if (isInputADate) {
         var earlyLimit = prerecordDateField.attr("min");
@@ -253,13 +253,16 @@ function verifyPrerecordDate() {
         var lateLimit = prerecordDateField.attr("max");
         var lateLimitMillisecs = new Date(lateLimit).getTime();
 
-        var startDatetimeMillisecs = new Date(prerecordDate).getTime();
+        var prerecordMoment = moment(prerecordDate);
+        var prerecordUTCOffset = prerecordMoment.utcOffset();
+        prerecordMoment.add(prerecordUTCOffset, 'minutes');
+        var prerecordDatetimeMillisecs = prerecordMoment.valueOf();
 
-        if (startDatetimeMillisecs < earlyLimitMillisecs) {
+        if (prerecordDatetimeMillisecs < earlyLimitMillisecs) {
             markPrerecordDateTooFarInPast(prerecordGroup, helpBlock);
             return false;
 
-        } else if (startDatetimeMillisecs > lateLimitMillisecs) {
+        } else if (prerecordDatetimeMillisecs > lateLimitMillisecs) {
             markPrerecordDateTooFarInFuture(prerecordGroup, helpBlock);
             return false;
 
@@ -274,11 +277,16 @@ function verifyPrerecordDate() {
     }
 }
 
-function _isDateTimeValid(startDatetimeInput) {
+function _isDateValid(dateInput) {
+    return (moment(dateInput, "YYYY-MM-DD", true).isValid() ||
+        moment(dateInput, "MM/DD/YYYY", true).isValid());
+}
+
+function _isDateTimeValid(datetimeInput) {
     // check for multiple kinds of date format, depending on browser used
-    return moment(startDatetimeInput, "YYYY-MM-DDTHH:mm", true).isValid() ||
-        moment(startDatetimeInput, "YYYY-MM-DDTHH:mm:ss", true).isValid() ||
-        moment(startDatetimeInput, "MM/DD/YYYY h:mm A", true).isValid();
+    return moment(datetimeInput, "YYYY-MM-DDTHH:mm", true).isValid() ||
+        moment(datetimeInput, "YYYY-MM-DDTHH:mm:ss", true).isValid() ||
+        moment(datetimeInput, "MM/DD/YYYY h:mm A", true).isValid();
 }
 
 function _getDateFromField(field) {

--- a/public_html/new-logsheet.php
+++ b/public_html/new-logsheet.php
@@ -48,11 +48,11 @@ $existingEpisodeId = $_GET['epId'];
         $smarty->assign("programs", $programs);
 
         $episodeStartEarlyLimitDatetime = EpisodeValidator::getEpisodeEarlyLimit();
-        $episodeStartEarlyLimit = $episodeStartEarlyLimitDatetime->format("Y-m-d H:i:s");
+        $episodeStartEarlyLimit = $episodeStartEarlyLimitDatetime->format("Y-m-d\TH:i:s");
         $smarty->assign("episodeStartEarlyLimit", $episodeStartEarlyLimit);
 
         $episodeStartLateLimitDatetime = EpisodeValidator::getEpisodeLateLimit();
-        $episodeStartLateLimit = $episodeStartLateLimitDatetime->format("Y-m-d H:i:s");
+        $episodeStartLateLimit = $episodeStartLateLimitDatetime->format("Y-m-d\TH:i:s");
         $smarty->assign("episodeStartLateLimit", $episodeStartLateLimit);
 
         $prerecordDateEarlyDaysLimit = EpisodeValidator::getPrerecordDateEarlyDaysLimit();

--- a/public_html/save-episode.php
+++ b/public_html/save-episode.php
@@ -99,7 +99,9 @@ function getDateTimeFromDateString($dateString) {
     $d = new DateTime($dateString);
     //$d = DateTime::createFromFormat('Y-m-d', $dateString);
 
-    if ($d && $d->format('Y-m-d') === $dateString) {
+    if ($d &&
+        ($d->format('Y-m-d') === $dateString ||
+            $d->format('m/d/Y') === $dateString)) {
 
         return new DateTime($dateString);
 
@@ -149,8 +151,8 @@ function getDateTimeFromDateTimeString($dateString) {
     //$d = DateTime::createFromFormat('Y-m-d\TH:i', $dateString);
 
     if ($d &&
-        ($d->format('Y-m-d\TH:i') === $dateString) ||
-        ($d->format('m/d/Y g:i A') === $dateString)){
+        ($d->format('Y-m-d\TH:i') === $dateString ||
+         $d->format('m/d/Y g:i A') === $dateString)){
 
         return new DateTime($dateString, new DateTimeZone('America/Montreal'));
 

--- a/public_html/save-episode.php
+++ b/public_html/save-episode.php
@@ -56,8 +56,6 @@ try {
     $episodeObject = fillEpisodeObject($db, $episodeObject, $programId, $programmer,
         $episodeStartTime, $episodeEndTime, $prerecord, $prerecordDate, $notes);
 
-    error_log("episode object: " . print_r($episodeObject, true));
-
     $episodeValidator = new EpisodeValidator($episodeObject);
     $episodeErrors = $episodeValidator->checkDraftSaveValidity();
 
@@ -117,22 +115,22 @@ function getDateTimeFromDateString($dateString) {
  * @param Episode $episodeObject
  * @param $programId
  * @param $programmer
- * @param $episodeStartTime
- * @param $episodeEndTime
+ * @param $episodeStartTimeString
+ * @param $episodeEndTimeString
  * @param $prerecord
  * @param $prerecordDate
  * @param $notes
  * @return Episode
  */
-function fillEpisodeObject($db, $episodeObject, $programId, $programmer, $episodeStartTime, $episodeEndTime, $prerecord, $prerecordDate, $notes) {
+function fillEpisodeObject($db, $episodeObject, $programId, $programmer, $episodeStartTimeString, $episodeEndTimeString, $prerecord, $prerecordDate, $notes) {
 
     $episodeObject->setProgram(new Program($db, $programId));
     $episodeObject->setProgrammer($programmer);
 
-    $episodeStartTime = getDateTimeFromDateTimeString($episodeStartTime);
+    $episodeStartTime = getDateTimeFromDateTimeString($episodeStartTimeString);
     $episodeObject->setStartTime($episodeStartTime);
 
-    $episodeEndTime = getDateTimeFromDateTimeString($episodeEndTime);
+    $episodeEndTime = getDateTimeFromDateTimeString($episodeEndTimeString);
     $episodeObject->setEndTime($episodeEndTime);
 
     $episodeObject->setIsPrerecord($prerecord);
@@ -150,7 +148,10 @@ function getDateTimeFromDateTimeString($dateString) {
     $d = new DateTime($dateString);
     //$d = DateTime::createFromFormat('Y-m-d\TH:i', $dateString);
 
-    if ($d && $d->format('Y-m-d\TH:i') === $dateString) {
+    if ($d &&
+        ($d->format('Y-m-d\TH:i') === $dateString) ||
+        ($d->format('m/d/Y g:i A') === $dateString)){
+
         return new DateTime($dateString, new DateTimeZone('America/Montreal'));
 
     } else {


### PR DESCRIPTION
Date and time fields would previously only show users a template on Chrome. The system now uses a JavaScript widget https://github.com/Eonasdan/bootstrap-datetimepicker that allows users to pick a date (instead of typing manually) on Safari and Firefox.

Also adds corrections and refinements to review logsheet page.